### PR TITLE
feat(auth): add User SQLModel and migration

### DIFF
--- a/alembic/versions/002_add_user_table.py
+++ b/alembic/versions/002_add_user_table.py
@@ -1,0 +1,37 @@
+"""add user table
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-05-01
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+revision: str = "002"
+down_revision: str | None = "001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "app_user",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("email", sqlmodel.sql.sqltypes.AutoString(length=320), nullable=False),
+        sa.Column("password_hash", sqlmodel.sql.sqltypes.AutoString(length=255), nullable=False),
+        sa.Column("is_verified", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_app_user_email", "app_user", ["email"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_app_user_email", table_name="app_user")
+    op.drop_table("app_user")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,6 @@
 """SQLModel database models."""
 
 from app.models.todo import Todo
+from app.models.user import User
 
-__all__ = ["Todo"]
+__all__ = ["Todo", "User"]

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,32 @@
+"""User model.
+
+Single user table for the marketplace — the same row plays both buyer
+(searches, favorites, bids) and seller (lists). Identity is by email.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlmodel import Field, SQLModel
+
+
+class User(SQLModel, table=True):
+    """A registered user account."""
+
+    # `user` is reserved in Postgres; pick a non-reserved table name.
+    __tablename__ = "app_user"
+
+    id: int | None = Field(default=None, primary_key=True)
+    email: str = Field(max_length=320, unique=True, index=True)
+    password_hash: str = Field(max_length=255)
+    is_verified: bool = Field(default=False)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    def __init__(self, **data: Any) -> None:
+        # SQLite has no CITEXT and SQLModel's `table=True` classes bypass
+        # Pydantic validators on instantiation, so normalize the email here.
+        # The UNIQUE index on email enforces the deduplication.
+        email = data.get("email")
+        if isinstance(email, str):
+            data["email"] = email.strip().lower()
+        super().__init__(**data)

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -1,0 +1,45 @@
+"""Tests for the User model."""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, select
+
+from app.models import User
+
+
+def test_persist_and_retrieve_by_email(session: Session) -> None:
+    user = User(email="alice@example.com", password_hash="$2b$12$placeholder")
+    session.add(user)
+    session.commit()
+
+    found = session.exec(select(User).where(User.email == "alice@example.com")).one()
+    assert found.id is not None
+    assert found.email == "alice@example.com"
+    assert found.is_verified is False
+    assert found.password_hash == "$2b$12$placeholder"
+
+
+def test_email_normalized_to_lowercase_and_stripped(session: Session) -> None:
+    user = User(email="  ALICE@Example.COM ", password_hash="$2b$12$placeholder")
+    session.add(user)
+    session.commit()
+    assert user.email == "alice@example.com"
+
+
+def test_duplicate_email_raises_integrity_error(session: Session) -> None:
+    session.add(User(email="alice@example.com", password_hash="hash1"))
+    session.commit()
+
+    session.add(User(email="alice@example.com", password_hash="hash2"))
+    with pytest.raises(IntegrityError):
+        session.commit()
+
+
+def test_duplicate_email_case_insensitive(session: Session) -> None:
+    """Validator lowercases on insert, so 'ALICE@..' duplicates 'alice@..'."""
+    session.add(User(email="alice@example.com", password_hash="hash1"))
+    session.commit()
+
+    session.add(User(email="ALICE@EXAMPLE.COM", password_hash="hash2"))
+    with pytest.raises(IntegrityError):
+        session.commit()


### PR DESCRIPTION
## Summary

Closes #6.

- Adds `User` SQLModel (`app/models/user.py`) with `id`, `email`, `password_hash`, `is_verified`, `created_at`.
- Alembic revision `002_add_user_table.py` creates `app_user` (the table name avoids the Postgres reserved word `user`) with a unique index on `email`. Fully reversible.
- Email is normalized (`strip().lower()`) on instantiation and the UNIQUE index enforces deduplication. SQLite has no `CITEXT` and SQLModel's `table=True` classes bypass Pydantic validators on `__init__`, so normalization lives in an `__init__` override — this is a documented SQLModel workaround.

Password hashing logic and signup/login endpoints are intentionally out of scope for this ticket — they live in follow-up tickets in the Identity & Auth epic (#1).

## Test plan

- [x] `uv run ruff check .` — zero errors
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy app/` — zero errors (`Success: no issues found in 11 source files`)
- [x] `uv run pytest` — 26 passed (4 new in `tests/models/test_user.py`)
- [x] `alembic upgrade head` against fresh SQLite — clean (`001 -> 002`)
- [x] `alembic downgrade -1` against fresh SQLite — clean (returns to `001`)
- [ ] Reviewer can run `uv run alembic upgrade head` against the preview Neon branch and confirm `app_user` exists with unique index on `email`.

## Tests added

- `test_persist_and_retrieve_by_email` — basic CRUD by email lookup
- `test_email_normalized_to_lowercase_and_stripped` — verifies the `__init__` normalization
- `test_duplicate_email_raises_integrity_error` — UNIQUE constraint
- `test_duplicate_email_case_insensitive` — confirms normalization + UNIQUE combine to prevent case-variant dupes

## Notes for reviewer

- The branch was cut off `main` while uncommitted bootstrap-phase changes (agent specializations, `CLAUDE.md` placeholders, `docs/TECHNICAL-ARCHITECTURE.md`, `docs/UPSTREAM-TEMPLATE-FEEDBACK.md`, etc.) sat in the working tree. **None of those are in this PR.** They need their own follow-up `chore(bootstrap): ...` PR.
- This PR is schema only. Auth flow tickets (`signup`, `verify`, `login`, `logout`) are still in Backlog under epic #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
