### PR TITLE
feat(catalog): add Listing and Photo SQLModels and migration

### DIFF
--- a/alembic/versions/003_add_listing_and_photo.py
+++ b/alembic/versions/003_add_listing_and_photo.py
@@ -1,0 +1,60 @@
+"""add listing and photo tables
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-05-02
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+revision: str = "003"
+down_revision: str | None = "002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "listing",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("seller_id", sa.Integer(), nullable=False),
+        sa.Column("title", sqlmodel.sql.sqltypes.AutoString(length=200), nullable=False),
+        sa.Column("description", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("era", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=True),
+        sa.Column("manufacturer", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=True),
+        sa.Column("condition", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=True),
+        sa.Column("status", sqlmodel.sql.sqltypes.AutoString(length=20), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["seller_id"], ["app_user.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_listing_seller_id", "listing", ["seller_id"])
+
+    op.create_table(
+        "photo",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("listing_id", sa.Integer(), nullable=False),
+        sa.Column("gcs_key", sqlmodel.sql.sqltypes.AutoString(length=500), nullable=False),
+        sa.Column("thumb_key", sqlmodel.sql.sqltypes.AutoString(length=500), nullable=True),
+        sa.Column("sort_order", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["listing_id"], ["listing.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_photo_listing_id_sort_order",
+        "photo",
+        ["listing_id", "sort_order"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_photo_listing_id_sort_order", table_name="photo")
+    op.drop_table("photo")
+    op.drop_index("ix_listing_seller_id", table_name="listing")
+    op.drop_table("listing")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,7 @@
 """SQLModel database models."""
 
+from app.models.listing import Listing, Photo
 from app.models.todo import Todo
 from app.models.user import User
 
-__all__ = ["Todo", "User"]
+__all__ = ["Listing", "Photo", "Todo", "User"]

--- a/app/models/listing.py
+++ b/app/models/listing.py
@@ -1,0 +1,68 @@
+"""Listing and Photo models for the marketplace catalog.
+
+A `Listing` is a single stuffed-animal-for-sale post owned by a `User`
+(via `seller_id`). A `Listing` has zero or more `Photo` rows; deleting
+a `Listing` cascades to its `Photo`s at both the ORM and DB level.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import Column, ForeignKey, Index, Integer
+from sqlmodel import Field, Relationship, SQLModel
+
+VALID_STATUSES = frozenset({"active", "sold", "withdrawn"})
+
+
+class Listing(SQLModel, table=True):
+    """A stuffed-animal listing posted by a seller."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    seller_id: int = Field(foreign_key="app_user.id", index=True)
+    title: str = Field(max_length=200)
+    description: str
+    era: str | None = Field(default=None, max_length=100)
+    manufacturer: str | None = Field(default=None, max_length=100)
+    condition: str | None = Field(default=None, max_length=100)
+    status: str = Field(default="active", max_length=20)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    photos: list["Photo"] = Relationship(
+        back_populates="listing",
+        sa_relationship_kwargs={
+            "cascade": "all, delete-orphan",
+            "order_by": "Photo.sort_order",
+        },
+    )
+
+    def __init__(self, **data: Any) -> None:
+        # SQLModel `table=True` classes bypass Pydantic validators on
+        # instantiation, so enforce the status whitelist here. A Postgres
+        # ENUM was intentionally avoided per the ticket guardrails — string
+        # + app-level whitelist keeps migrations cheap when statuses change.
+        status = data.get("status", "active")
+        if status not in VALID_STATUSES:
+            raise ValueError(
+                f"Listing.status must be one of {sorted(VALID_STATUSES)}, got {status!r}"
+            )
+        super().__init__(**data)
+
+
+class Photo(SQLModel, table=True):
+    """A photo attached to a listing."""
+
+    __table_args__ = (Index("ix_photo_listing_id_sort_order", "listing_id", "sort_order"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    listing_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("listing.id", ondelete="CASCADE"),
+            nullable=False,
+        )
+    )
+    gcs_key: str = Field(max_length=500)
+    thumb_key: str | None = Field(default=None, max_length=500)
+    sort_order: int = Field(default=0)
+
+    listing: Listing | None = Relationship(back_populates="photos")

--- a/tests/models/test_listing.py
+++ b/tests/models/test_listing.py
@@ -1,0 +1,82 @@
+"""Tests for the Listing and Photo models."""
+
+import pytest
+from sqlmodel import Session, select
+
+from app.models import Listing, Photo, User
+
+
+def test_user_listing_photos_chain_and_ordering(session: Session) -> None:
+    seller = User(email="seller@example.com", password_hash="$2b$12$placeholder")
+    session.add(seller)
+    session.commit()
+    session.refresh(seller)
+    assert seller.id is not None
+
+    listing = Listing(
+        seller_id=seller.id,
+        title="Vintage Beanie Baby",
+        description="Patti the Platypus, 1993, mint condition",
+        era="1990s",
+        manufacturer="Ty",
+        condition="mint",
+    )
+    session.add(listing)
+    session.commit()
+    session.refresh(listing)
+    assert listing.id is not None
+
+    # Insert photos out of sort_order on purpose to verify ordering.
+    session.add(Photo(listing_id=listing.id, gcs_key="photos/1.jpg", sort_order=1))
+    session.add(Photo(listing_id=listing.id, gcs_key="photos/0.jpg", sort_order=0))
+    session.commit()
+
+    found = session.exec(select(Listing).where(Listing.id == listing.id)).one()
+    assert found.title == "Vintage Beanie Baby"
+    assert found.status == "active"
+    assert len(found.photos) == 2
+    assert [p.sort_order for p in found.photos] == [0, 1]
+    assert [p.gcs_key for p in found.photos] == ["photos/0.jpg", "photos/1.jpg"]
+
+
+def test_deleting_listing_cascades_to_photos(session: Session) -> None:
+    seller = User(email="seller2@example.com", password_hash="hash")
+    session.add(seller)
+    session.commit()
+    session.refresh(seller)
+    assert seller.id is not None
+
+    listing = Listing(seller_id=seller.id, title="A bear", description="brown teddy")
+    session.add(listing)
+    session.commit()
+    session.refresh(listing)
+    assert listing.id is not None
+
+    session.add(Photo(listing_id=listing.id, gcs_key="a.jpg"))
+    session.add(Photo(listing_id=listing.id, gcs_key="b.jpg"))
+    session.commit()
+
+    listing_id = listing.id
+    assert len(session.exec(select(Photo).where(Photo.listing_id == listing_id)).all()) == 2
+
+    session.delete(listing)
+    session.commit()
+
+    assert session.exec(select(Listing).where(Listing.id == listing_id)).first() is None
+    assert session.exec(select(Photo).where(Photo.listing_id == listing_id)).all() == []
+
+
+def test_invalid_status_raises_validation_error() -> None:
+    with pytest.raises(ValueError, match="status"):
+        Listing(seller_id=1, title="x", description="y", status="invalid")
+
+
+def test_default_status_is_active() -> None:
+    listing = Listing(seller_id=1, title="x", description="y")
+    assert listing.status == "active"
+
+
+def test_explicit_valid_statuses_accepted() -> None:
+    for status in ("active", "sold", "withdrawn"):
+        listing = Listing(seller_id=1, title="x", description="y", status=status)
+        assert listing.status == status


### PR DESCRIPTION
## Summary

Adds the catalog primitives the marketplace is built around:

- `Listing` — a single stuffed-animal-for-sale post owned by a `User` (via `seller_id` FK to `app_user.id`)
- `Photo` — zero or more per listing, ordered by `sort_order`, with `ON DELETE CASCADE`
- Alembic migration `003_add_listing_and_photo` (reversible, tested up + down on fresh SQLite)
- Five tests covering the chain, ordering, cascade delete, and `status` validation

## Design choices (per ticket #7 guardrails)

- **No `price` column.** v1 has no fixed price; bids drive valuation.
- **`status` is a plain string**, validated in `__init__` to `active | sold | withdrawn`. SQLModel `table=True` classes bypass Pydantic validators on instantiation, so the User model's `__init__`-validation pattern is reused. A Postgres ENUM was intentionally avoided to keep migrations cheap if statuses change.
- **No `embedding` column** — that lives in #8 (`ListingEmbedding`).
- **Photo cascade is enforced both ways:** ORM-level via `cascade="all, delete-orphan"` (so the SQLite test session deletes photos when a listing is deleted, even without `PRAGMA foreign_keys=ON`), and DB-level via `ON DELETE CASCADE` on the FK (so direct SQL deletes against Postgres also cascade).
- **Composite index** `(listing_id, sort_order)` on `photo` so per-listing photo lookups stay sorted without a sort step.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format .` — clean
- [x] `uv run mypy app/` — clean
- [x] `uv run pytest` — 31 passed (5 new)
- [x] `uv run alembic upgrade head` then `downgrade -1` then `upgrade head` against fresh SQLite — all succeed
- [ ] Reviewer: run `uv run alembic upgrade head` against the preview Neon branch and confirm both tables and the composite index exist

Closes #7